### PR TITLE
Replace Unix zip command with cross-platform Node.js script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build:functionapp": "npm run functionapp:compile && npm run functionapp:zip",
     "build:frontdoor": "npx perimeterx-azure-js-sdk -e src/enforcerConfig.json",
     "functionapp:compile": "rollup -c rollup.config.js --bundleConfigAsCjs",
-    "functionapp:zip": "zip -qr EnforcerFunction.zip EnforcerFunction host.json"
+    "functionapp:zip": "node scripts/zip.js"
   },
   "dependencies": {
     "perimeterx-azure-js-sdk": "^1.3.0"
@@ -17,6 +17,7 @@
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-typescript": "^12.1.4",
     "@types/node": "^24.0.7",
+    "adm-zip": "^0.5.16",
     "rollup": "^4.44.1",
     "tslib": "^2.8.1",
     "typescript": "^5.8.3"

--- a/scripts/zip.js
+++ b/scripts/zip.js
@@ -1,0 +1,6 @@
+const AdmZip = require('adm-zip');
+
+const zip = new AdmZip();
+zip.addLocalFolder('EnforcerFunction', 'EnforcerFunction');
+zip.addLocalFile('host.json');
+zip.writeZip('EnforcerFunction.zip');


### PR DESCRIPTION
The functionapp:zip script used the Unix zip CLI which fails on Windows. Replace with scripts/zip.js using adm-zip.